### PR TITLE
fix(ci): Fix release asset creation by using release-please outputs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,8 +5,6 @@ on:
     branches:
       - main
       - master
-  release:
-    types: [published]
 
 permissions:
   contents: write
@@ -16,6 +14,9 @@ jobs:
   release-please:
     name: Release Please
     runs-on: ubuntu-latest
+    outputs:
+      release_created: ${{ steps.release.outputs['release_created'] }}
+      tag_name: ${{ steps.release.outputs['tag_name'] }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -31,12 +32,13 @@ jobs:
   release:
     name: Create Release Assets
     runs-on: ubuntu-latest
-    if: github.event_name == 'release'
+    needs: release-please
+    if: ${{ needs.release-please.outputs.release_created == 'true' }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.release.tag_name }}
+          ref: ${{ needs.release-please.outputs.tag_name }}
 
       - name: Create release zip
         run: |
@@ -46,6 +48,7 @@ jobs:
       - name: Upload release assets
         uses: softprops/action-gh-release@v2
         with:
+          tag_name: ${{ needs.release-please.outputs.tag_name }}
           files: azimut_energy.zip
 
   validate:


### PR DESCRIPTION
The release job was checking for `github.event_name == 'release'`, but release-please triggers the workflow via a push event. Changed to:
- Add outputs from release-please job (release_created, tag_name)
- Make release job depend on release-please job
- Check release_created output instead of event type
- Use tag_name output for checkout and upload steps
- Remove unused release event trigger

## Description

<!-- Provide a clear and concise description of what this PR does -->

## Type of Change

<!-- Mark the relevant option(s) with an "x" -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Dependency update

## Related Issue

<!-- If this PR addresses an issue, link it here -->
Closes #

## Changes Made

<!-- List the main changes made in this PR -->

-
-
-

## Testing

<!-- Describe the tests you ran to verify your changes -->

- [ ] Tested locally with Home Assistant devcontainer
- [ ] All existing tests pass (`pytest`)
- [ ] Added new tests for new functionality
- [ ] Manually tested the integration in a running HA instance

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Checklist

<!-- Mark completed items with an "x" -->

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Additional Notes

<!-- Add any other context about the PR here -->
