### PR TITLE
fix(lint): remove unused imports in test files

### DIFF
--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -5,12 +5,10 @@ from __future__ import annotations
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from homeassistant.const import CONF_HOST
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
-from pytest_homeassistant_custom_component.common import MockConfigEntry
 
-from custom_components.azimut_energy.const import CONF_SERIAL, DOMAIN  # noqa: I001
+from custom_components.azimut_energy.const import DOMAIN
 
 
 async def test_setup_entry_success(

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -8,10 +8,9 @@ from unittest.mock import MagicMock, patch
 import pytest
 from homeassistant.core import HomeAssistant
 from homeassistant.util import dt as dt_util
-from pytest_homeassistant_custom_component.common import MockConfigEntry
 
-from custom_components.azimut_energy.const import CONF_SERIAL, DOMAIN  # noqa: I001
-from custom_components.azimut_energy.sensor import (  # noqa: I001
+from custom_components.azimut_energy.const import CONF_SERIAL, DOMAIN
+from custom_components.azimut_energy.sensor import (
     AzimutDiagnosticSensor,
     AzimutSensor,
 )


### PR DESCRIPTION
Remove unused imports flagged by ruff:
- tests/test_init.py: CONF_HOST, MockConfigEntry, CONF_SERIAL
- tests/test_sensor.py: MockConfigEntry