### PR TITLE
feat: Add republish command to MQTT topic

### DIFF
--- a/custom_components/azimut_energy/const.py
+++ b/custom_components/azimut_energy/const.py
@@ -31,6 +31,15 @@ def get_state_topic(serial: str) -> str:
     return f"{STATE_TOPIC_PREFIX}/{serial}/sensor/+/state"
 
 
+def get_republish_command_topic(serial: str) -> str:
+    """Get the republish command topic for a device serial.
+
+    Publishing any message to this topic triggers the device to republish
+    all sensor values. The payload content is ignored.
+    """
+    return f"{STATE_TOPIC_PREFIX}/{serial}/command/republish"
+
+
 # Icon mapping
 ICON_GRID = "mdi:transmission-tower"
 ICON_BATTERY = "mdi:battery"

--- a/custom_components/azimut_energy/mqtt_client.py
+++ b/custom_components/azimut_energy/mqtt_client.py
@@ -15,6 +15,7 @@ import aiomqtt
 from .const import (
     MQTT_KEEPALIVE,
     get_discovery_topic,
+    get_republish_command_topic,
     get_state_topic,
 )
 
@@ -66,6 +67,7 @@ class AzimutMQTTClient:
         # Topic patterns
         self._discovery_topic = get_discovery_topic(serial)
         self._state_topic = get_state_topic(serial)
+        self._republish_command_topic = get_republish_command_topic(serial)
 
         # Regex patterns for parsing topics
         # Discovery: homeassistant/sensor/azen_{serial}/{sensor_id}/config
@@ -139,6 +141,25 @@ class AzimutMQTTClient:
             self._last_disconnect_time = time.time()
             if self._connection_callback:
                 self._connection_callback(False)
+
+    async def _request_republish(self) -> None:
+        """Request republish of all sensor values.
+
+        Publishes an empty message to the republish command topic to trigger
+        the device to republish all sensor values. This is called on reconnect
+        to ensure sensors get their initial values.
+        """
+        if not self._client:
+            return
+
+        try:
+            await self._client.publish(self._republish_command_topic, payload="")
+            _LOGGER.debug(
+                "Requested republish of sensor values on topic %s",
+                self._republish_command_topic,
+            )
+        except Exception as err:
+            _LOGGER.warning("Failed to request republish: %s", err)
 
     async def connect(self) -> bool:
         """Connect to MQTT broker (for initial validation only)."""
@@ -223,6 +244,9 @@ class AzimutMQTTClient:
 
                     self._notify_connected()
                     self._last_message_time = time.monotonic()
+
+                    # Request republish of all sensor values on reconnect
+                    await self._request_republish()
 
                     # Listen for messages with timeout
                     await self._listen_loop_with_timeout()

--- a/tests/test_mqtt_client.py
+++ b/tests/test_mqtt_client.py
@@ -464,3 +464,39 @@ async def test_connection_tracking_edge_cases(mqtt_client: AzimutMQTTClient) -> 
     first_disconnect_time = mqtt_client.last_disconnect_time
     mqtt_client._notify_disconnected()  # Duplicate notification
     assert mqtt_client.last_disconnect_time == first_disconnect_time  # No change
+
+
+async def test_republish_command_topic(mqtt_client: AzimutMQTTClient) -> None:
+    """Test republish command topic is correctly set."""
+    assert mqtt_client._republish_command_topic == "azen/ABC123/command/republish"
+
+
+async def test_request_republish_success(mqtt_client: AzimutMQTTClient) -> None:
+    """Test successful republish request."""
+    mock_client = MagicMock()
+    mock_client.publish = AsyncMock()
+    mqtt_client._client = mock_client
+
+    await mqtt_client._request_republish()
+
+    mock_client.publish.assert_called_once_with(
+        "azen/ABC123/command/republish", payload=""
+    )
+
+
+async def test_request_republish_no_client(mqtt_client: AzimutMQTTClient) -> None:
+    """Test republish request does nothing when client is None."""
+    mqtt_client._client = None
+
+    # Should not raise an error
+    await mqtt_client._request_republish()
+
+
+async def test_request_republish_handles_error(mqtt_client: AzimutMQTTClient) -> None:
+    """Test republish request handles errors gracefully."""
+    mock_client = MagicMock()
+    mock_client.publish = AsyncMock(side_effect=Exception("Publish failed"))
+    mqtt_client._client = mock_client
+
+    # Should not raise an error
+    await mqtt_client._request_republish()


### PR DESCRIPTION
Publish to azen/{serial}/command/republish on MQTT reconnect to trigger the device to republish all sensor values. This ensures Home Assistant receives current sensor values after connection loss.

External tools can also trigger republish by publishing any message to this topic (e.g., mosquitto_pub -t "azen/ABC123/command/republish" -m "")

## Description

<!-- Provide a clear and concise description of what this PR does -->

## Type of Change

<!-- Mark the relevant option(s) with an "x" -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Dependency update

## Related Issue

<!-- If this PR addresses an issue, link it here -->
Closes #

## Changes Made

<!-- List the main changes made in this PR -->

-
-
-

## Testing

<!-- Describe the tests you ran to verify your changes -->

- [x] Tested locally with Home Assistant devcontainer
- [x] All existing tests pass (`pytest`)
- [x] Added new tests for new functionality
- [ ] Manually tested the integration in a running HA instance

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Checklist

<!-- Mark completed items with an "x" -->

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Additional Notes

<!-- Add any other context about the PR here -->
