### PR TITLE
fix(mqtt): sensors remain available on MQTT disconnect

### DIFF
--- a/custom_components/azimut_energy/sensor.py
+++ b/custom_components/azimut_energy/sensor.py
@@ -122,12 +122,14 @@ async def async_setup_entry(
 
     @callback
     def handle_connection_change(connected: bool) -> None:
-        """Handle MQTT connection state change."""
-        if not connected:
-            # Mark all sensors as unavailable when connection is lost
-            for sensor in created_sensors.values():
-                sensor.set_connection_available(False)
-        # When connected, sensors will become available when they receive data
+        """Handle MQTT connection state change.
+
+        Note: We intentionally do NOT mark sensors as unavailable on disconnect.
+        Sensors should only become unavailable when their expire_after timeout hits
+        (no value received for the configured amount of time).
+        """
+        for sensor in created_sensors.values():
+            sensor.set_connection_state(connected)
 
     # Register callbacks with coordinator
     coordinator.set_discovery_callback(handle_discovery)
@@ -229,12 +231,13 @@ class AzimutSensor(SensorEntity):
         self.async_write_ha_state()
 
     @callback
-    def set_connection_available(self, connected: bool) -> None:
-        """Set availability based on MQTT connection state."""
+    def set_connection_state(self, connected: bool) -> None:
+        """Track MQTT connection state.
+
+        Note: This does NOT change sensor availability. Sensors remain available
+        until their expire_after timeout hits (no value received for X seconds).
+        """
         self._mqtt_connected = connected
-        if not connected and self._attr_available:
-            self._attr_available = False
-            self.async_write_ha_state()
 
     async def async_added_to_hass(self) -> None:
         """Run when entity is added to hass."""
@@ -258,12 +261,12 @@ class AzimutSensor(SensorEntity):
 
     @callback
     def _check_expiration(self, now: datetime) -> None:
-        """Check if sensor has expired due to no updates."""
-        if self._last_update is None:
-            return
+        """Check if sensor has expired due to no updates.
 
-        # Only check expiration if MQTT is connected
-        if not self._mqtt_connected:
+        Expiration is checked regardless of MQTT connection state. This ensures
+        sensors become unavailable based on data freshness, not connection status.
+        """
+        if self._last_update is None:
             return
 
         if (now - self._last_update).total_seconds() > self._expire_after:

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -211,12 +211,16 @@ async def test_sensor_state_routing(
     assert sensor.native_value == 92.0
 
 
-async def test_sensor_connection_availability(
+async def test_sensor_remains_available_on_disconnect(
     hass: HomeAssistant,
     mock_coordinator: MagicMock,
     sample_discovery_payload: dict,
 ) -> None:
-    """Test sensor availability based on connection state."""
+    """Test sensor remains available when connection is lost.
+
+    Sensors should only become unavailable when their expire_after timeout hits,
+    not immediately when the MQTT connection drops.
+    """
     sensor = AzimutSensor(
         coordinator=mock_coordinator,
         payload=sample_discovery_payload,
@@ -229,10 +233,12 @@ async def test_sensor_connection_availability(
         sensor.update_value(50.0)
     assert sensor.available
 
-    # Simulate connection loss
-    with patch.object(sensor, "async_write_ha_state"):
-        sensor.set_connection_available(False)
-    assert not sensor.available
+    # Simulate connection loss - sensor should REMAIN available
+    sensor.set_connection_state(False)
+    assert sensor.available  # Sensor should still be available
+
+    # Verify connection state is tracked
+    assert not sensor._mqtt_connected
 
 
 async def test_sensor_expiration(
@@ -261,6 +267,41 @@ async def test_sensor_expiration(
         sensor._check_expiration(dt_util.utcnow())
 
     # Sensor should be unavailable
+    assert not sensor.available
+
+
+async def test_sensor_expiration_when_disconnected(
+    hass: HomeAssistant,
+    mock_coordinator: MagicMock,
+    sample_discovery_payload: dict,
+) -> None:
+    """Test sensor expiration works even when MQTT is disconnected.
+
+    Sensors should become unavailable based on data freshness, not connection state.
+    """
+    sensor = AzimutSensor(
+        coordinator=mock_coordinator,
+        payload=sample_discovery_payload,
+        serial="ABC123",
+    )
+    sensor.hass = hass
+
+    # Set initial value
+    with patch.object(sensor, "async_write_ha_state"):
+        sensor.update_value(1000.0)
+    assert sensor.available
+
+    # Simulate connection loss
+    sensor.set_connection_state(False)
+    assert sensor.available  # Still available after disconnect
+
+    # Simulate time passing beyond expiration (300 seconds)
+    sensor._last_update = dt_util.utcnow() - timedelta(seconds=301)
+
+    with patch.object(sensor, "async_write_ha_state"):
+        sensor._check_expiration(dt_util.utcnow())
+
+    # Sensor should become unavailable due to expiration, even though disconnected
     assert not sensor.available
 
 


### PR DESCRIPTION
Sensors now only become unavailable when their expire_after timeout hits
(no value received for the configured amount of time), rather than
immediately when the MQTT connection drops.

Changes:
- Renamed set_connection_available to set_connection_state to reflect
  that it only tracks connection state without affecting availability
- Removed immediate unavailability marking on disconnect
- Expiration check now runs regardless of MQTT connection state
- Updated tests to verify sensors remain available after disconnect
- Added new test for expiration behavior when disconnected