### PR TITLE
feat: Add total solar power/energy computed sensors + clarify translations for PV/MPPT

### DIFF
--- a/custom_components/azimut_energy/sensor.py
+++ b/custom_components/azimut_energy/sensor.py
@@ -18,8 +18,12 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.event import async_track_time_interval
 from homeassistant.util import dt as dt_util
 
-from .const import CONF_SERIAL, DEFAULT_EXPIRE_AFTER, DOMAIN
+from .const import CONF_SERIAL, DEFAULT_EXPIRE_AFTER, DOMAIN, ICON_SOLAR
 from .types import DiscoveryPayload
+
+# Sensor IDs that contribute to total solar power/energy
+_SOLAR_POWER_SOURCES = {"pv_power", "mppt_power"}
+_SOLAR_ENERGY_SOURCES = {"pv_energy", "mppt_energy"}
 
 if TYPE_CHECKING:
     from . import AzimutMQTTCoordinator
@@ -55,6 +59,9 @@ async def async_setup_entry(
 
     # Track created sensors by unique_id to avoid duplicates
     created_sensors: dict[str, AzimutSensor] = {}
+
+    # Total solar computed sensors (created on first solar source discovery)
+    total_solar_sensors: dict[str, AzimutTotalSolarSensor] = {}
 
     # Create diagnostic sensors
     sensor_count_diag = AzimutDiagnosticSensor(
@@ -107,19 +114,77 @@ async def async_setup_entry(
         # Update sensor count
         sensor_count_diag.increment_sensor_count()
 
-        # Add the entity
-        async_add_entities([sensor])
+        new_entities: list[SensorEntity] = [sensor]
+
+        # Check if this is a solar source sensor -> create total solar sensor
+        sensor_type = ""
+        if unique_id:
+            parts = unique_id.split("_", 2)
+            if len(parts) >= 3:
+                sensor_type = parts[2]
+
+        if sensor_type in _SOLAR_POWER_SOURCES:
+            total_key = "total_solar_power"
+            if total_key not in total_solar_sensors:
+                total_sensor = AzimutTotalSolarSensor(
+                    serial=serial,
+                    sensor_type=total_key,
+                    unit="W",
+                    device_class=SensorDeviceClass.POWER,
+                    state_class=SensorStateClass.MEASUREMENT,
+                    device_info=sensor.device_info,
+                )
+                total_solar_sensors[total_key] = total_sensor
+                new_entities.append(total_sensor)
+                sensor_count_diag.increment_sensor_count()
+
+        if sensor_type in _SOLAR_ENERGY_SOURCES:
+            total_key = "total_solar_energy"
+            if total_key not in total_solar_sensors:
+                total_sensor = AzimutTotalSolarSensor(
+                    serial=serial,
+                    sensor_type=total_key,
+                    unit="kWh",
+                    device_class=SensorDeviceClass.ENERGY,
+                    state_class=SensorStateClass.TOTAL_INCREASING,
+                    device_info=sensor.device_info,
+                )
+                total_solar_sensors[total_key] = total_sensor
+                new_entities.append(total_sensor)
+                sensor_count_diag.increment_sensor_count()
+
+        # Add entities
+        async_add_entities(new_entities)
         _LOGGER.info("Created sensor: %s", unique_id)
 
     @callback
     def handle_state_update(state_topic: str, value: float) -> None:
         """Handle state update and route to correct sensor."""
+        matched_sensor: AzimutSensor | None = None
         for sensor in created_sensors.values():
             if sensor.state_topic == state_topic:
                 sensor.update_value(value)
-                return
+                matched_sensor = sensor
+                break
 
-        _LOGGER.debug("No sensor found for state topic: %s", state_topic)
+        if matched_sensor is None:
+            _LOGGER.debug("No sensor found for state topic: %s", state_topic)
+            return
+
+        # Update total solar sensors if this is a solar source
+        unique_id = matched_sensor.unique_id or ""
+        parts = unique_id.split("_", 2)
+        sensor_type = parts[2] if len(parts) >= 3 else ""
+
+        if sensor_type in _SOLAR_POWER_SOURCES:
+            total = total_solar_sensors.get("total_solar_power")
+            if total:
+                total.update_source(sensor_type, value)
+
+        if sensor_type in _SOLAR_ENERGY_SOURCES:
+            total = total_solar_sensors.get("total_solar_energy")
+            if total:
+                total.update_source(sensor_type, value)
 
     @callback
     def handle_connection_change(connected: bool) -> None:
@@ -359,4 +424,43 @@ class AzimutDiagnosticSensor(SensorEntity):
     @callback
     def _async_update(self, now: datetime) -> None:
         """Update the sensor value."""
+        self.async_write_ha_state()
+
+
+class AzimutTotalSolarSensor(SensorEntity):
+    """Computed sensor that sums PV (AC-coupled) and MPPT (DC-coupled) values."""
+
+    _attr_has_entity_name = True
+
+    def __init__(
+        self,
+        serial: str,
+        sensor_type: str,
+        unit: str,
+        device_class: SensorDeviceClass,
+        state_class: SensorStateClass,
+        device_info: DeviceInfo | None,
+    ) -> None:
+        """Initialize the total solar sensor."""
+        self._attr_unique_id = f"azen_{serial}_{sensor_type}"
+        self._attr_translation_key = sensor_type
+        self._attr_native_unit_of_measurement = unit
+        self._attr_device_class = device_class
+        self._attr_state_class = state_class
+        self._attr_icon = ICON_SOLAR
+        self._attr_native_value: float | None = None
+        self._attr_available = False
+
+        if device_info:
+            self._attr_device_info = device_info
+
+        # Track source values
+        self._source_values: dict[str, float] = {}
+
+    @callback
+    def update_source(self, source_key: str, value: float) -> None:
+        """Update one source value and recompute total."""
+        self._source_values[source_key] = value
+        self._attr_native_value = round(sum(self._source_values.values()), 2)
+        self._attr_available = True
         self.async_write_ha_state()

--- a/custom_components/azimut_energy/strings.json
+++ b/custom_components/azimut_energy/strings.json
@@ -97,16 +97,22 @@
         "name": "Grid energy export"
       },
       "pv_power": {
-        "name": "PV power"
+        "name": "Solar power (AC-coupled)"
       },
       "pv_energy": {
-        "name": "Solar energy total"
+        "name": "Solar energy (AC-coupled)"
       },
       "mppt_power": {
-        "name": "MPPT power"
+        "name": "Solar power (DC-coupled / MPPT)"
       },
       "mppt_energy": {
-        "name": "MPPT energy total"
+        "name": "Solar energy (DC-coupled / MPPT)"
+      },
+      "total_solar_power": {
+        "name": "Total solar power"
+      },
+      "total_solar_energy": {
+        "name": "Total solar energy"
       },
       "inverter_power": {
         "name": "Inverter power"

--- a/custom_components/azimut_energy/translations/de.json
+++ b/custom_components/azimut_energy/translations/de.json
@@ -97,16 +97,22 @@
         "name": "Energieexport ins Netz"
       },
       "pv_power": {
-        "name": "PV-Leistung"
+        "name": "Solarleistung (AC-gekoppelt)"
       },
       "pv_energy": {
-        "name": "Solarenergie gesamt"
+        "name": "Solarenergie (AC-gekoppelt)"
       },
       "mppt_power": {
-        "name": "MPPT-Leistung"
+        "name": "Solarleistung (DC-gekoppelt / MPPT)"
       },
       "mppt_energy": {
-        "name": "MPPT-Energie gesamt"
+        "name": "Solarenergie (DC-gekoppelt / MPPT)"
+      },
+      "total_solar_power": {
+        "name": "Gesamte Solarleistung"
+      },
+      "total_solar_energy": {
+        "name": "Gesamte Solarenergie"
       },
       "inverter_power": {
         "name": "Wechselrichterleistung"

--- a/custom_components/azimut_energy/translations/en.json
+++ b/custom_components/azimut_energy/translations/en.json
@@ -97,16 +97,22 @@
         "name": "Grid energy export"
       },
       "pv_power": {
-        "name": "PV power"
+        "name": "Solar power (AC-coupled)"
       },
       "pv_energy": {
-        "name": "Solar energy total"
+        "name": "Solar energy (AC-coupled)"
       },
       "mppt_power": {
-        "name": "MPPT power"
+        "name": "Solar power (DC-coupled / MPPT)"
       },
       "mppt_energy": {
-        "name": "MPPT energy total"
+        "name": "Solar energy (DC-coupled / MPPT)"
+      },
+      "total_solar_power": {
+        "name": "Total solar power"
+      },
+      "total_solar_energy": {
+        "name": "Total solar energy"
       },
       "inverter_power": {
         "name": "Inverter power"

--- a/custom_components/azimut_energy/translations/fr.json
+++ b/custom_components/azimut_energy/translations/fr.json
@@ -97,16 +97,22 @@
         "name": "Énergie exportée vers le réseau"
       },
       "pv_power": {
-        "name": "Puissance photovoltaïque"
+        "name": "Puissance solaire (couplage AC)"
       },
       "pv_energy": {
-        "name": "Énergie solaire totale"
+        "name": "Énergie solaire (couplage AC)"
       },
       "mppt_power": {
-        "name": "Puissance MPPT"
+        "name": "Puissance solaire (couplage DC / MPPT)"
       },
       "mppt_energy": {
-        "name": "Énergie MPPT totale"
+        "name": "Énergie solaire (couplage DC / MPPT)"
+      },
+      "total_solar_power": {
+        "name": "Puissance solaire totale"
+      },
+      "total_solar_energy": {
+        "name": "Énergie solaire totale"
       },
       "inverter_power": {
         "name": "Puissance de l'onduleur"

--- a/custom_components/azimut_energy/translations/nl.json
+++ b/custom_components/azimut_energy/translations/nl.json
@@ -97,16 +97,22 @@
         "name": "Energie-export naar net"
       },
       "pv_power": {
-        "name": "PV-vermogen"
+        "name": "Zonne-vermogen (AC-gekoppeld)"
       },
       "pv_energy": {
-        "name": "Totale zonne-energie"
+        "name": "Zonne-energie (AC-gekoppeld)"
       },
       "mppt_power": {
-        "name": "MPPT-vermogen"
+        "name": "Zonne-vermogen (DC-gekoppeld / MPPT)"
       },
       "mppt_energy": {
-        "name": "Totale MPPT-energie"
+        "name": "Zonne-energie (DC-gekoppeld / MPPT)"
+      },
+      "total_solar_power": {
+        "name": "Totaal zonne-vermogen"
+      },
+      "total_solar_energy": {
+        "name": "Totaal zonne-energie"
       },
       "inverter_power": {
         "name": "Omvormervermogen"

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -714,9 +714,7 @@ async def test_total_solar_power_created_on_pv_discovery(
     # Should create pv_power + total_solar_power
     sensors = add_entities_mock.call_args_list[1][0][0]
     assert len(sensors) == 2
-    total_sensor = next(
-        s for s in sensors if isinstance(s, AzimutTotalSolarSensor)
-    )
+    total_sensor = next(s for s in sensors if isinstance(s, AzimutTotalSolarSensor))
     assert total_sensor.unique_id == "azen_ABC123_total_solar_power"
     assert total_sensor.translation_key == "total_solar_power"
 
@@ -876,9 +874,7 @@ async def test_total_solar_energy_created_on_energy_discovery(
 
     sensors = add_entities_mock.call_args_list[1][0][0]
     assert len(sensors) == 2
-    total_sensor = next(
-        s for s in sensors if isinstance(s, AzimutTotalSolarSensor)
-    )
+    total_sensor = next(s for s in sensors if isinstance(s, AzimutTotalSolarSensor))
     assert total_sensor.unique_id == "azen_ABC123_total_solar_energy"
     assert total_sensor.translation_key == "total_solar_energy"
 

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -13,6 +13,7 @@ from custom_components.azimut_energy.const import CONF_SERIAL, DOMAIN
 from custom_components.azimut_energy.sensor import (
     AzimutDiagnosticSensor,
     AzimutSensor,
+    AzimutTotalSolarSensor,
 )
 
 
@@ -662,3 +663,287 @@ async def test_diagnostic_sensor_default_value(
         icon="mdi:counter",
     )
     assert sensor.native_value == 0
+
+
+async def test_total_solar_power_created_on_pv_discovery(
+    hass: HomeAssistant,
+    mock_coordinator: MagicMock,
+) -> None:
+    """Test total solar power sensor is created when pv_power is discovered."""
+    from custom_components.azimut_energy.sensor import async_setup_entry
+
+    entry = MagicMock()
+    entry.data = {CONF_SERIAL: "ABC123"}
+    entry.entry_id = "test_entry"
+
+    hass.data[DOMAIN] = {entry.entry_id: mock_coordinator}
+
+    mqtt_client = MagicMock()
+    mqtt_client.reconnect_count = 0
+    mqtt_client.total_messages_received = 0
+    mock_coordinator.mqtt_client = mqtt_client
+
+    callbacks = {}
+    mock_coordinator.set_discovery_callback.side_effect = lambda cb: callbacks.update(
+        {"discovery": cb}
+    )
+    mock_coordinator.set_state_callback.side_effect = lambda cb: callbacks.update(
+        {"state": cb}
+    )
+    mock_coordinator.set_connection_callback.side_effect = lambda cb: None
+
+    add_entities_mock = MagicMock()
+    await async_setup_entry(hass, entry, add_entities_mock)
+
+    # Discover pv_power sensor
+    pv_payload = {
+        "unique_id": "azen_ABC123_pv_power",
+        "name": "PV Power",
+        "state_topic": "azen/ABC123/sensor/pv_power/state",
+        "unit_of_measurement": "W",
+        "device_class": "power",
+        "state_class": "measurement",
+        "device": {
+            "identifiers": ["azen_ABC123"],
+            "name": "Azen ABC123",
+            "manufacturer": "Azimut",
+        },
+    }
+    callbacks["discovery"](pv_payload)
+
+    # Should create pv_power + total_solar_power
+    sensors = add_entities_mock.call_args_list[1][0][0]
+    assert len(sensors) == 2
+    total_sensor = next(
+        s for s in sensors if isinstance(s, AzimutTotalSolarSensor)
+    )
+    assert total_sensor.unique_id == "azen_ABC123_total_solar_power"
+    assert total_sensor.translation_key == "total_solar_power"
+
+
+async def test_total_solar_power_created_once(
+    hass: HomeAssistant,
+    mock_coordinator: MagicMock,
+) -> None:
+    """Test total solar power sensor is created only once even with both PV and MPPT."""
+    from custom_components.azimut_energy.sensor import async_setup_entry
+
+    entry = MagicMock()
+    entry.data = {CONF_SERIAL: "ABC123"}
+    entry.entry_id = "test_entry"
+
+    hass.data[DOMAIN] = {entry.entry_id: mock_coordinator}
+
+    mqtt_client = MagicMock()
+    mqtt_client.reconnect_count = 0
+    mqtt_client.total_messages_received = 0
+    mock_coordinator.mqtt_client = mqtt_client
+
+    callbacks = {}
+    mock_coordinator.set_discovery_callback.side_effect = lambda cb: callbacks.update(
+        {"discovery": cb}
+    )
+    mock_coordinator.set_state_callback.side_effect = lambda cb: callbacks.update(
+        {"state": cb}
+    )
+    mock_coordinator.set_connection_callback.side_effect = lambda cb: None
+
+    add_entities_mock = MagicMock()
+    await async_setup_entry(hass, entry, add_entities_mock)
+
+    base_payload = {
+        "unit_of_measurement": "W",
+        "device_class": "power",
+        "state_class": "measurement",
+        "device": {
+            "identifiers": ["azen_ABC123"],
+            "name": "Azen ABC123",
+            "manufacturer": "Azimut",
+        },
+    }
+
+    # Discover pv_power (creates total_solar_power)
+    pv_payload = {
+        **base_payload,
+        "unique_id": "azen_ABC123_pv_power",
+        "name": "PV Power",
+        "state_topic": "azen/ABC123/sensor/pv_power/state",
+    }
+    callbacks["discovery"](pv_payload)
+
+    # Discover mppt_power (total_solar_power already exists)
+    mppt_payload = {
+        **base_payload,
+        "unique_id": "azen_ABC123_mppt_power",
+        "name": "MPPT Power",
+        "state_topic": "azen/ABC123/sensor/mppt_power/state",
+    }
+    callbacks["discovery"](mppt_payload)
+
+    # First discovery creates pv_power + total_solar_power (2 sensors)
+    first_call_sensors = add_entities_mock.call_args_list[1][0][0]
+    assert len(first_call_sensors) == 2
+
+    # Second discovery creates only mppt_power (1 sensor, no duplicate total)
+    second_call_sensors = add_entities_mock.call_args_list[2][0][0]
+    assert len(second_call_sensors) == 1
+    assert second_call_sensors[0].unique_id == "azen_ABC123_mppt_power"
+
+
+async def test_total_solar_power_sums_sources(
+    hass: HomeAssistant,
+    mock_coordinator: MagicMock,
+) -> None:
+    """Test total solar power sensor sums PV and MPPT values."""
+    from homeassistant.components.sensor import SensorDeviceClass, SensorStateClass
+
+    total_sensor = AzimutTotalSolarSensor(
+        serial="ABC123",
+        sensor_type="total_solar_power",
+        unit="W",
+        device_class=SensorDeviceClass.POWER,
+        state_class=SensorStateClass.MEASUREMENT,
+        device_info=None,
+    )
+    total_sensor.hass = hass
+
+    # Initially unavailable
+    assert not total_sensor.available
+    assert total_sensor.native_value is None
+
+    # Update pv_power
+    with patch.object(total_sensor, "async_write_ha_state"):
+        total_sensor.update_source("pv_power", 1500.0)
+    assert total_sensor.native_value == 1500.0
+    assert total_sensor.available
+
+    # Update mppt_power
+    with patch.object(total_sensor, "async_write_ha_state"):
+        total_sensor.update_source("mppt_power", 800.5)
+    assert total_sensor.native_value == 2300.5
+
+    # Update pv_power again
+    with patch.object(total_sensor, "async_write_ha_state"):
+        total_sensor.update_source("pv_power", 1200.0)
+    assert total_sensor.native_value == 2000.5
+
+
+async def test_total_solar_energy_created_on_energy_discovery(
+    hass: HomeAssistant,
+    mock_coordinator: MagicMock,
+) -> None:
+    """Test total solar energy sensor is created when energy sources are discovered."""
+    from custom_components.azimut_energy.sensor import async_setup_entry
+
+    entry = MagicMock()
+    entry.data = {CONF_SERIAL: "ABC123"}
+    entry.entry_id = "test_entry"
+
+    hass.data[DOMAIN] = {entry.entry_id: mock_coordinator}
+
+    mqtt_client = MagicMock()
+    mqtt_client.reconnect_count = 0
+    mqtt_client.total_messages_received = 0
+    mock_coordinator.mqtt_client = mqtt_client
+
+    callbacks = {}
+    mock_coordinator.set_discovery_callback.side_effect = lambda cb: callbacks.update(
+        {"discovery": cb}
+    )
+    mock_coordinator.set_state_callback.side_effect = lambda cb: callbacks.update(
+        {"state": cb}
+    )
+    mock_coordinator.set_connection_callback.side_effect = lambda cb: None
+
+    add_entities_mock = MagicMock()
+    await async_setup_entry(hass, entry, add_entities_mock)
+
+    # Discover mppt_energy sensor
+    energy_payload = {
+        "unique_id": "azen_ABC123_mppt_energy",
+        "name": "MPPT Energy",
+        "state_topic": "azen/ABC123/sensor/mppt_energy/state",
+        "unit_of_measurement": "kWh",
+        "device_class": "energy",
+        "state_class": "total_increasing",
+        "device": {
+            "identifiers": ["azen_ABC123"],
+            "name": "Azen ABC123",
+            "manufacturer": "Azimut",
+        },
+    }
+    callbacks["discovery"](energy_payload)
+
+    sensors = add_entities_mock.call_args_list[1][0][0]
+    assert len(sensors) == 2
+    total_sensor = next(
+        s for s in sensors if isinstance(s, AzimutTotalSolarSensor)
+    )
+    assert total_sensor.unique_id == "azen_ABC123_total_solar_energy"
+    assert total_sensor.translation_key == "total_solar_energy"
+
+
+async def test_total_solar_updated_via_state_callback(
+    hass: HomeAssistant,
+    mock_coordinator: MagicMock,
+) -> None:
+    """Test total solar sensor is updated when state updates arrive."""
+    from custom_components.azimut_energy.sensor import async_setup_entry
+
+    entry = MagicMock()
+    entry.data = {CONF_SERIAL: "ABC123"}
+    entry.entry_id = "test_entry"
+
+    hass.data[DOMAIN] = {entry.entry_id: mock_coordinator}
+
+    mqtt_client = MagicMock()
+    mqtt_client.reconnect_count = 0
+    mqtt_client.total_messages_received = 0
+    mock_coordinator.mqtt_client = mqtt_client
+
+    callbacks = {}
+    mock_coordinator.set_discovery_callback.side_effect = lambda cb: callbacks.update(
+        {"discovery": cb}
+    )
+    mock_coordinator.set_state_callback.side_effect = lambda cb: callbacks.update(
+        {"state": cb}
+    )
+    mock_coordinator.set_connection_callback.side_effect = lambda cb: None
+
+    add_entities_mock = MagicMock()
+    await async_setup_entry(hass, entry, add_entities_mock)
+
+    # Discover pv_power
+    pv_payload = {
+        "unique_id": "azen_ABC123_pv_power",
+        "name": "PV Power",
+        "state_topic": "azen/ABC123/sensor/pv_power/state",
+        "unit_of_measurement": "W",
+        "device_class": "power",
+        "state_class": "measurement",
+        "device": {
+            "identifiers": ["azen_ABC123"],
+            "name": "Azen ABC123",
+            "manufacturer": "Azimut",
+        },
+    }
+    callbacks["discovery"](pv_payload)
+
+    # Get the sensors
+    created_sensors = add_entities_mock.call_args_list[1][0][0]
+    pv_sensor = next(s for s in created_sensors if isinstance(s, AzimutSensor))
+    total_sensor = next(
+        s for s in created_sensors if isinstance(s, AzimutTotalSolarSensor)
+    )
+    pv_sensor.hass = hass
+    total_sensor.hass = hass
+
+    # Send state update via callback
+    with (
+        patch.object(pv_sensor, "async_write_ha_state"),
+        patch.object(total_sensor, "async_write_ha_state"),
+    ):
+        callbacks["state"]("azen/ABC123/sensor/pv_power/state", 2000.0)
+
+    assert pv_sensor.native_value == 2000.0
+    assert total_sensor.native_value == 2000.0


### PR DESCRIPTION
## Description

This PR adds computed sensors that automatically sum solar power and energy from multiple sources (PV/AC-coupled and MPPT/DC-coupled). When any solar source sensor is discovered, a corresponding total solar sensor is created and updated in real-time as source values change.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Changes Made

- Added `AzimutTotalSolarSensor` class that computes totals by summing multiple source values
- Automatically creates `total_solar_power` sensor when any power source (pv_power, mppt_power) is discovered
- Automatically creates `total_solar_energy` sensor when any energy source (pv_energy, mppt_energy) is discovered
- Total sensors are created only once, even if multiple sources are discovered
- Total sensors update in real-time when source values change via state callbacks
- Updated sensor names in all language files to clarify AC-coupled vs DC-coupled sources
- Added new translation keys for total_solar_power and total_solar_energy in all supported languages (en, de, fr, nl)

## Testing

- [x] Added comprehensive unit tests covering:
  - Total solar power sensor creation on PV discovery
  - Duplicate prevention when multiple sources are discovered
  - Value summation from multiple sources
  - Total solar energy sensor creation
  - Real-time updates via state callbacks
- [x] All existing tests pass
- [x] New tests validate the complete lifecycle of computed sensors

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation (translation strings)
- [x] My changes generate no new warnings
- [x] I have added tests that prove the feature works
- [x] New and existing unit tests pass locally with my changes

https://claude.ai/code/session_01DpJjWxdQAFSaSXTWbNzYdS